### PR TITLE
docs: mention the type of API key required

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Supported providers:
 - `datamuse` ([datamuse.com])
 - `freedictionaryapi` ([dictionaryapi.dev])
 
-Register at [dictionaryapi.com] and get an API key. Set it as
+Register at [dictionaryapi.com] and get an API key (type: `Collegiate Thesaurus`). Set it as
 `vim.g.dictionary_api_key` or `DICTIONARY_API_KEY` environment variable.
 
 To set a different provider, set options from Telescope config. If you're using


### PR DESCRIPTION
The sign-up form lets you select a maximum of 2 key types (out of ~9 choices). The `collegiate thesaurus` type works OK. The `collegiate dictionary` does not:

```
Unable to decode response:Invalid API key. Not subscribed for this reference.
```

FWIW, there were also other choices like `learners thesaurus`, `intermediate thesaurus` etc.
